### PR TITLE
CompatHelper: add new compat entry for DataStructures at version 0.18, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,6 +24,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
+DataStructures = "0.18"
 julia = "1.6"
 
 [extras]


### PR DESCRIPTION
This pull request sets the compat entry for the `DataStructures` package to `0.18`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.
Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.