### PR TITLE
CompatHelper: add new compat entry for Pipe at version 1, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,6 +25,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 GaussianRandomFields = "2"
+Pipe = "1"
 julia = "1.6"
 
 [extras]


### PR DESCRIPTION
This pull request sets the compat entry for the `Pipe` package to `1`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.
Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.